### PR TITLE
#50 파티 생성 백엔드 연동

### DIFF
--- a/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
+++ b/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
@@ -12,11 +12,11 @@ export type UpdateFormData = (
 export type PartySurveyFormData = {
   cragName: string
   locationId: number
-  members: number
+  maximumParticipationNumber: number
   gender: string
-  subject: string // @desc 종목
+  climbingType: string // @desc 종목
   partyName: string
-  partyIntroduce: string
+  partyDescription: string
   partyDate: string
   partyTime: string
   minSkillLevel: number
@@ -25,7 +25,7 @@ export type PartySurveyFormData = {
 }
 export type Condition = Pick<
   PartySurveyFormData,
-  'members' | 'gender' | 'subject' | 'minSkillLevel' | 'maxSkillLevel'
+  'maximumParticipationNumber' | 'gender' | 'climbingType' | 'minSkillLevel' | 'maxSkillLevel'
 >
 export type Schedule = Pick<PartySurveyFormData, 'partyDate' | 'partyTime'>
 
@@ -33,11 +33,11 @@ export function PartySurveyFormPage() {
   const [formData, setFormData] = useState<PartySurveyFormData>({
     cragName: '',
     locationId: 0,
-    members: 3,
+    maximumParticipationNumber: 3,
     gender: '남녀 모두',
-    subject: '볼더링',
+    climbingType: '볼더링',
     partyName: '',
-    partyIntroduce: '',
+    partyDescription: '',
     partyDate: new Date().toISOString().substring(0, 10),
     partyTime: '18:00',
     minSkillLevel: 0,

--- a/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
+++ b/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
@@ -3,6 +3,7 @@ import styles from './PartySurveyFormPage.module.scss'
 import { PartyTypeForm } from './components/PartyTypeForm.tsx'
 import { IndoorStep, OutdoorStep } from './components/Steps.tsx'
 import TopBar from '@/components/NavBar/TopBar.tsx'
+import { ClimbingTypeKo, GenderKo } from '@/pages/PartySurveyForm/components/PartyConditionForm.tsx'
 
 export type UpdateFormData = (
   key: keyof PartySurveyFormData,
@@ -13,8 +14,8 @@ export type PartySurveyFormData = {
   cragName: string
   locationId: number
   maximumParticipationNumber: number
-  gender: string
-  climbingType: string // @desc 종목
+  gender: GenderKo
+  climbingType: ClimbingTypeKo
   partyName: string
   partyDescription: string
   partyDate: string

--- a/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
+++ b/src/pages/PartySurveyForm/PartySurveyFormPage.tsx
@@ -22,6 +22,7 @@ export type PartySurveyFormData = {
   minSkillLevel: number
   maxSkillLevel: number
   isNatural: boolean
+  approachDescription: string
 }
 export type Condition = Pick<
   PartySurveyFormData,
@@ -43,6 +44,7 @@ export function PartySurveyFormPage() {
     minSkillLevel: 0,
     maxSkillLevel: 5,
     isNatural: false,
+    approachDescription: '',
   })
   const [isFirstStep, setIsFirstStep] = useState(true)
 

--- a/src/pages/PartySurveyForm/components/PartyConditionForm.tsx
+++ b/src/pages/PartySurveyForm/components/PartyConditionForm.tsx
@@ -13,12 +13,9 @@ type PartyConditionFormProps = {
   updateFormData: UpdateFormData
 }
 
-type Gender = '남녀 모두' | '남자만' | '여자만'
-type Subject = '볼더링' | '리드' | '지구력' | '상관없음'
-
 export function PartyConditionForm({ onNext, formData, updateFormData }: PartyConditionFormProps) {
-  const genderList: Gender[] = ['남녀 모두', '남자만', '여자만']
-  const subjectList: Subject[] = ['볼더링', '리드', '지구력', '상관없음']
+  const genderList: GenderKo[] = ['남녀 모두', '남자만', '여자만']
+  const subjectList: ClimbingTypeKo[] = ['볼더링', '리드', '지구력', '상관없음']
   const [condition, setCondition] = useState<Condition>({
     maximumParticipationNumber: formData.maximumParticipationNumber,
     gender: formData.gender,
@@ -47,7 +44,7 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
                   max={12}
                   value={condition.maximumParticipationNumber}
                   onChange={(e) => {
-                    updateConditionData('maximumParticipationNumber', e.target.value)
+                    updateConditionData('maximumParticipationNumber', Number(e.target.value))
                   }}
                 />
               </AccordionContent>
@@ -60,7 +57,7 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
               <AccordionContent>
                 <RadioButtonGroup
                   list={genderList}
-                  onValueChange={(value) => updateConditionData('gender', value)}
+                  onValueChange={(value) => updateConditionData('gender', value as GenderKo)}
                   defaultValue={condition.gender}
                 />
               </AccordionContent>
@@ -73,7 +70,9 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
               <AccordionContent>
                 <RadioButtonGroup
                   list={subjectList}
-                  onValueChange={(value) => updateConditionData('climbingType', value)}
+                  onValueChange={(value) =>
+                    updateConditionData('climbingType', value as ClimbingTypeKo)
+                  }
                   defaultValue={condition.climbingType}
                 />
               </AccordionContent>
@@ -139,3 +138,20 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
     </div>
   )
 }
+
+export const Gender = {
+  BOTH: '남녀 모두',
+  MALE_ONLY: '남자만',
+  FEMALE_ONLY: '여자만',
+} as const
+export type GenderEn = keyof typeof Gender
+export type GenderKo = (typeof Gender)[GenderEn]
+
+const ClimbingType = {
+  BOULDERING: '볼더링',
+  LEAD: '리드',
+  ENDURANCE: '지구력',
+  ANY: '상관없음',
+} as const
+export type ClimbingTypeEn = keyof typeof ClimbingType
+export type ClimbingTypeKo = (typeof ClimbingType)[ClimbingTypeEn]

--- a/src/pages/PartySurveyForm/components/PartyConditionForm.tsx
+++ b/src/pages/PartySurveyForm/components/PartyConditionForm.tsx
@@ -20,9 +20,9 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
   const genderList: Gender[] = ['남녀 모두', '남자만', '여자만']
   const subjectList: Subject[] = ['볼더링', '리드', '지구력', '상관없음']
   const [condition, setCondition] = useState<Condition>({
-    members: formData.members,
+    maximumParticipationNumber: formData.maximumParticipationNumber,
     gender: formData.gender,
-    subject: formData.subject,
+    climbingType: formData.climbingType,
     minSkillLevel: formData.minSkillLevel,
     maxSkillLevel: formData.maxSkillLevel,
   })
@@ -39,15 +39,15 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
           <div className={styles.question}>
             <h3 className={styles.questionTitle}>파티 인원 (본인 포함)</h3>
             <Accordion.Item className="AccordionItem" value={`members`}>
-              <AccordionTrigger>{condition.members}</AccordionTrigger>
+              <AccordionTrigger>{condition.maximumParticipationNumber}</AccordionTrigger>
               <AccordionContent>
                 <input
                   type="number"
                   min={2}
                   max={12}
-                  value={condition.members}
+                  value={condition.maximumParticipationNumber}
                   onChange={(e) => {
-                    updateConditionData('members', e.target.value)
+                    updateConditionData('maximumParticipationNumber', e.target.value)
                   }}
                 />
               </AccordionContent>
@@ -69,12 +69,12 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
           <div className={styles.question}>
             <h3 className={styles.questionTitle}>종목</h3>
             <Accordion.Item className="AccordionItem" value={`subject`}>
-              <AccordionTrigger>{condition.subject}</AccordionTrigger>
+              <AccordionTrigger>{condition.climbingType}</AccordionTrigger>
               <AccordionContent>
                 <RadioButtonGroup
                   list={subjectList}
-                  onValueChange={(value) => updateConditionData('subject', value)}
-                  defaultValue={condition.subject}
+                  onValueChange={(value) => updateConditionData('climbingType', value)}
+                  defaultValue={condition.climbingType}
                 />
               </AccordionContent>
             </Accordion.Item>
@@ -125,9 +125,9 @@ export function PartyConditionForm({ onNext, formData, updateFormData }: PartyCo
         <button
           className={styles.nextBtn}
           onClick={() => {
-            updateFormData('members', condition.members)
+            updateFormData('maximumParticipationNumber', condition.maximumParticipationNumber)
             updateFormData('gender', condition.gender)
-            updateFormData('subject', condition.subject)
+            updateFormData('climbingType', condition.climbingType)
             updateFormData('minSkillLevel', condition.minSkillLevel)
             updateFormData('maxSkillLevel', condition.maxSkillLevel)
             onNext()

--- a/src/pages/PartySurveyForm/components/PartyIntroduceForm.tsx
+++ b/src/pages/PartySurveyForm/components/PartyIntroduceForm.tsx
@@ -11,7 +11,7 @@ type PartyIntroduceFormProps = {
 
 export function PartyIntroduceForm({ onNext, formData, updateFormData }: PartyIntroduceFormProps) {
   const [partyName, setPartyName] = useState(formData.partyName)
-  const [partyIntroduce, setPartyIntroduce] = useState(formData.partyIntroduce)
+  const [partyIntroduce, setPartyIntroduce] = useState(formData.partyDescription)
 
   const disabled = partyName.length < 5 || partyIntroduce.length < 10
 
@@ -56,7 +56,7 @@ export function PartyIntroduceForm({ onNext, formData, updateFormData }: PartyIn
               return
             }
             updateFormData('partyName', partyName)
-            updateFormData('partyIntroduce', partyIntroduce)
+            updateFormData('partyDescription', partyIntroduce)
             onNext()
           }}
         >

--- a/src/pages/PartySurveyForm/components/Steps.tsx
+++ b/src/pages/PartySurveyForm/components/Steps.tsx
@@ -5,6 +5,7 @@ import { ClimbingTypeEn, GenderEn, PartyConditionForm } from './PartyConditionFo
 import { PartyIntroduceForm } from './PartyIntroduceForm.tsx'
 import { PartyScheduleForm } from './PartyScheduleForm.tsx'
 import { PartySurveyFormData, UpdateFormData } from '../PartySurveyFormPage.tsx'
+import { post_party_new, PostPartyNewReq } from '@/services/party.ts'
 
 const indoorSteps = ['암장', '조건', '소개', '일정'] as const
 type IndoorStepName = (typeof indoorSteps)[number]
@@ -84,8 +85,14 @@ export function IndoorStep({ formData, updateFormData }: StepProps) {
         </Step>
         <Step name="일정">
           <PartyScheduleForm
-            onNext={() => {
-              pop()
+            onNext={async () => {
+              try {
+                const reqBody: PostPartyNewReq = new PartyNewAdapter(formData).adapt()
+                await post_party_new(reqBody)
+                pop()
+              } catch (e) {
+                console.log(e)
+              }
             }}
             formData={formData}
             updateFormData={updateFormData}

--- a/src/pages/PartySurveyForm/components/Steps.tsx
+++ b/src/pages/PartySurveyForm/components/Steps.tsx
@@ -6,6 +6,7 @@ import { PartyIntroduceForm } from './PartyIntroduceForm.tsx'
 import { PartyScheduleForm } from './PartyScheduleForm.tsx'
 import { PartySurveyFormData, UpdateFormData } from '../PartySurveyFormPage.tsx'
 import { post_party_new, PostPartyNewReq } from '@/services/party.ts'
+import { useNavigate } from 'react-router-dom'
 
 const indoorSteps = ['암장', '조건', '소개', '일정'] as const
 type IndoorStepName = (typeof indoorSteps)[number]
@@ -21,7 +22,7 @@ type StepProps = {
 export function IndoorStep({ formData, updateFormData }: StepProps) {
   const { Funnel, Step, setStep, step } = useFunnel<IndoorStepName>('암장')
   const { stepPush } = useStepFlow('HomePage')
-  const { pop } = useFlow()
+  const navigate = useNavigate()
 
   const getCurrentStepIndex = (steps: readonly IndoorStepName[], step: IndoorStepName) => {
     return steps.findIndex((el) => el === step)
@@ -89,7 +90,7 @@ export function IndoorStep({ formData, updateFormData }: StepProps) {
               try {
                 const reqBody: PostPartyNewReq = new PartyNewAdapter(formData).adapt()
                 await post_party_new(reqBody)
-                pop()
+                navigate('/')
               } catch (e) {
                 console.log(e)
               }

--- a/src/pages/PartySurveyForm/components/Steps.tsx
+++ b/src/pages/PartySurveyForm/components/Steps.tsx
@@ -1,7 +1,7 @@
 import { useFunnel } from '../../../utils/useFunnel.tsx'
 import { useFlow, useStepFlow } from '../../stackflow.ts'
 import { PartyPlaceForm } from './PartyPlaceForm.tsx'
-import { PartyConditionForm } from './PartyConditionForm.tsx'
+import { ClimbingTypeEn, GenderEn, PartyConditionForm } from './PartyConditionForm.tsx'
 import { PartyIntroduceForm } from './PartyIntroduceForm.tsx'
 import { PartyScheduleForm } from './PartyScheduleForm.tsx'
 import { PartySurveyFormData, UpdateFormData } from '../PartySurveyFormPage.tsx'
@@ -148,4 +148,103 @@ export function OutdoorStep({ formData, updateFormData }: StepProps) {
       </Funnel>
     </>
   )
+}
+
+class PartyNewAdapter {
+  private value: PartySurveyFormData
+
+  constructor(value: PartySurveyFormData) {
+    this.value = value
+  }
+
+  get constraints(): GenderEn {
+    switch (this.value.gender) {
+      case '남녀 모두':
+        return 'BOTH'
+      case '남자만':
+        return 'MALE_ONLY'
+      case '여자만':
+        return 'FEMALE_ONLY'
+      default:
+        return 'BOTH'
+    }
+  }
+
+  get climbingType(): ClimbingTypeEn {
+    switch (this.value.climbingType) {
+      case '볼더링':
+        return 'BOULDERING'
+      case '리드':
+        return 'LEAD'
+      case '지구력':
+        return 'ENDURANCE'
+      case '상관없음':
+        return 'ANY'
+      default:
+        return 'ANY'
+    }
+  }
+
+  get maximumParticipationNumber(): number {
+    return this.value.maximumParticipationNumber
+  }
+
+  get partyTitle(): string {
+    return this.value.partyName
+  }
+
+  get isNatural(): boolean {
+    return this.value.isNatural
+  }
+
+  get minSkillLevel(): number {
+    return this.value.minSkillLevel
+  }
+
+  get maxSkillLevel(): number {
+    return this.value.maxSkillLevel
+  }
+
+  get locationId(): number {
+    return this.value.locationId
+  }
+
+  // @todo 임시로 설정
+  get participationDeadline(): string {
+    return this.appointmentTime
+  }
+
+  get approachDescription(): string {
+    return this.value.approachDescription
+  }
+
+  get partyDescription(): string {
+    return this.value.partyDescription
+  }
+
+  get appointmentTime(): string {
+    const date = this.value.partyDate
+    const time = this.value.partyTime
+    // @desc ss, ms는 입력받을 수 없으니 임의로 설정
+    const dummyTime = ':00.000Z'
+
+    return `${date}T${time}${dummyTime}`
+  }
+
+  adapt(): PostPartyNewReq {
+    return {
+      constraints: this.constraints,
+      climbingType: this.climbingType,
+      maximumParticipationNumber: this.maximumParticipationNumber,
+      partyTitle: this.partyTitle,
+      isNatural: this.isNatural,
+      minSkillLevel: this.minSkillLevel,
+      maxSkillLevel: this.maxSkillLevel,
+      locationId: this.locationId,
+      participationDeadline: this.participationDeadline,
+      approacheDescription: this.approachDescription,
+      partyDescription: this.partyDescription,
+      appointmentTime: this.appointmentTime,
+    }
+  }
 }

--- a/src/services/party.ts
+++ b/src/services/party.ts
@@ -1,0 +1,23 @@
+import api from '@/utils/api.ts'
+
+export type PostPartyNewReq = {
+  constraints: 'BOTH' | 'MALE_ONLY' | 'FEMALE_ONLY'
+  climbingType: 'BOULDERING' | 'LEAD' | 'ENDURANCE' | 'ANY'
+  maximumParticipationNumber: number
+  isNatural: boolean
+  minSkillLevel: number
+  maxSkillLevel: number
+  locationId: number
+  participationDeadline: string
+  approacheDescription: string
+  partyDescription: string
+  appointmentTime: string
+}
+
+export type PostPartyNewRes = {
+  partyId: number
+}
+
+export const post_party_new = async (reqBody: PostPartyNewReq) => {
+  return await api.post<PostPartyNewRes>('/v1/party/new', reqBody)
+}

--- a/src/services/party.ts
+++ b/src/services/party.ts
@@ -19,5 +19,11 @@ export type PostPartyNewRes = {
 }
 
 export const post_party_new = async (reqBody: PostPartyNewReq) => {
-  return await api.post<PostPartyNewRes>('/v1/party/new', reqBody)
+  try {
+    const result = await api.post<PostPartyNewRes>('/v1/party/new', reqBody)
+    return result
+  } catch (e) {
+    console.error(e)
+    throw new Error('파티 생성에 실패하였습니다. post v1/party/new')
+  }
 }

--- a/src/services/party.ts
+++ b/src/services/party.ts
@@ -1,9 +1,11 @@
 import api from '@/utils/api.ts'
+import { ClimbingTypeEn, GenderEn } from '@/pages/PartySurveyForm/components/PartyConditionForm.tsx'
 
 export type PostPartyNewReq = {
-  constraints: 'BOTH' | 'MALE_ONLY' | 'FEMALE_ONLY'
-  climbingType: 'BOULDERING' | 'LEAD' | 'ENDURANCE' | 'ANY'
+  constraints: GenderEn
+  climbingType: ClimbingTypeEn
   maximumParticipationNumber: number
+  partyTitle: string
   isNatural: boolean
   minSkillLevel: number
   maxSkillLevel: number


### PR DESCRIPTION
## 작업 내용

1. 파티 생성 요청을 위한 어댑터 클래스 생성
2. 파티 생성 폼 타입 변경
3. 마지막 스텝에서 다음 버튼 클릭 시 파티 생성 요청 보내는 기능 추가