### PR TITLE
#66 유저 추가 정보 입력 페이지

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toggle": "^1.0.3",
+    "@radix-ui/react-toggle-group": "^1.1.0",
     "@stackflow/core": "^1.0.10",
     "@stackflow/plugin-basic-ui": "^1.6.0",
     "@stackflow/plugin-history-sync": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@radix-ui/react-toggle':
     specifier: ^1.0.3
     version: 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+  '@radix-ui/react-toggle-group':
+    specifier: ^1.1.0
+    version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
   '@stackflow/core':
     specifier: ^1.0.10
     version: 1.0.10
@@ -1656,6 +1659,10 @@ packages:
       '@babel/runtime': 7.24.5
     dev: false
 
+  /@radix-ui/primitive@1.1.0:
+    resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+    dev: false
+
   /@radix-ui/react-accordion@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==}
     peerDependencies:
@@ -1782,6 +1789,29 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-collection@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.2)(react@18.3.1):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
@@ -1796,6 +1826,19 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
   /@radix-ui/react-context@1.0.1(@types/react@18.3.2)(react@18.3.1):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
@@ -1806,6 +1849,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-context@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false
@@ -1854,6 +1910,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-direction@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false
@@ -1931,6 +2000,20 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-id@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false
@@ -2029,6 +2112,26 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-radio-group@1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==}
     peerDependencies:
@@ -2082,6 +2185,34 @@ packages:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.2)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@types/react': 18.3.2
       '@types/react-dom': 18.3.0
       react: 18.3.1
@@ -2175,6 +2306,46 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@radix-ui/react-slot@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-toggle-group@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-PpTJV68dZU2oqqgq75Uzto5o/XfOVgkrJ9rulVmfTKxWp3HfUjHE6CP/WLRR4AzPX9HWxw7vFow2me85Yu+Naw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-toggle@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==}
     peerDependencies:
@@ -2198,6 +2369,28 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-toggle@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-gwoxaKZ0oJ4vIgzsfESBuSgJNdc0rv12VhHgcqN0TEJmmZixXG/2XpsLK8kzNWYcnaoRIEEQc0bEi3dIvdUpjw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.2)(react@18.3.1):
     resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
     peerDependencies:
@@ -2208,6 +2401,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false
@@ -2223,6 +2429,20 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.5
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.2)(react@18.3.1)
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false
@@ -2252,6 +2472,19 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.5
+      '@types/react': 18.3.2
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.2)(react@18.3.1):
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
       '@types/react': 18.3.2
       react: 18.3.1
     dev: false

--- a/src/pages/MyInfoFormPage/MyInfoFormPage.module.scss
+++ b/src/pages/MyInfoFormPage/MyInfoFormPage.module.scss
@@ -1,0 +1,45 @@
+.Container {
+  width: 100%;
+  position: relative;
+  padding-top: rem(48px);
+  height: calc(100vh);
+}
+
+.Main {
+  padding: rem(16px);
+  padding-bottom: rem(84px);
+
+  h1 {
+    font-size: rem(20px);
+    font-weight: 700;
+  }
+  h2 {
+    font-size: rem(16px);
+    font-weight: 700;
+  }
+
+  fieldset {
+    width: 100%;
+    margin: rem(16px) 0;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.Bottom {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background-color: white;
+  padding: rem(16px);
+  border-top: 1px solid $gray-100;
+
+  .Button {
+    width: 100%;
+    box-sizing: border-box;
+    height: rem(52px);
+    border-radius: rem(26px);
+    font-size: rem(16px);
+    font-weight: 700;
+  }
+}

--- a/src/pages/MyInfoFormPage/MyInfoFormPage.tsx
+++ b/src/pages/MyInfoFormPage/MyInfoFormPage.tsx
@@ -1,0 +1,86 @@
+import Chip from '@/components/Chip'
+import TopBar from '@/components/NavBar/TopBar'
+import styles from './MyInfoFormPage.module.scss'
+import ToggleSex from './components/ToggleSex'
+import { useState } from 'react'
+import {
+  AdditionalInfoAddapter,
+  MyInfo,
+  post_user_additionalInfo,
+  skillOptions,
+} from '@/services/user'
+
+const DEFAULT_SKILL = skillOptions[0]
+
+export default function MyInfoFormPage() {
+  const [sex, setSex] = useState<MyInfo['sex'] | ''>('')
+  const [skill, setSkill] = useState<MyInfo['skill'] | ''>(DEFAULT_SKILL)
+  const [description, setDescription] = useState<MyInfo['description']>('')
+
+  const disabled = !sex || !skill || !description
+
+  return (
+    <div className={styles.Container}>
+      <TopBar />
+
+      <div className={styles.Main}>
+        <h1>서비스 이용 시 필요한 정보입니다!</h1>
+
+        <fieldset>
+          <h2>성별</h2>
+          <ToggleSex sex={sex} setSex={setSex} />
+        </fieldset>
+
+        <fieldset>
+          <h2>실력</h2>
+          <select
+            value={skill}
+            defaultValue={DEFAULT_SKILL}
+            onChange={(e) => setSkill(e.target.value as MyInfo['skill'])}
+            name="skill"
+          >
+            {skillOptions.map((skill) => (
+              <option key={skill} value={skill}>
+                {skill}
+              </option>
+            ))}
+          </select>
+        </fieldset>
+
+        <fieldset>
+          <h2>소개</h2>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="소개를 입력해주세요"
+          />
+        </fieldset>
+      </div>
+
+      <div className={styles.Bottom}>
+        <Chip className={styles.Button} variable={disabled ? 'default' : 'primary'} asChild>
+          <button
+            disabled={disabled}
+            onClick={async () => {
+              if (disabled) return
+              try {
+                await post_user_additionalInfo(
+                  new AdditionalInfoAddapter({
+                    description,
+                    sex,
+                    skill,
+                  }).adapt()
+                )
+                console.log('저장 성공')
+              } catch (e) {
+                console.error(e)
+              }
+            }}
+          >
+            저장하기
+          </button>
+        </Chip>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/MyInfoFormPage/components/ToggleSex.module.scss
+++ b/src/pages/MyInfoFormPage/components/ToggleSex.module.scss
@@ -1,0 +1,23 @@
+.ToggleGroup {
+  display: flex;
+  justify-content: space-between;
+  gap: rem(16px);
+}
+
+.ToggleGroupItem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: rem(14px);
+  width: 50%;
+  color: $gray-900;
+  border: 1px solid $gray-900;
+  padding: rem(6px);
+  border-radius: rem(10px);
+  cursor: pointer;
+}
+
+.ToggleGroupItem[data-state='on'] {
+  background-color: $gray-900;
+  color: white;
+}

--- a/src/pages/MyInfoFormPage/components/ToggleSex.tsx
+++ b/src/pages/MyInfoFormPage/components/ToggleSex.tsx
@@ -1,0 +1,29 @@
+import * as ToggleGroup from '@radix-ui/react-toggle-group'
+import styles from './ToggleSex.module.scss'
+import { MyInfo } from '@/services/user'
+
+type Props = {
+  sex: MyInfo['sex'] | ''
+  setSex: (sex: MyInfo['sex']) => void
+}
+
+export default function ToggleSex({ sex, setSex }: Props) {
+  return (
+    <ToggleGroup.Root
+      value={sex}
+      onValueChange={(sex) => {
+        if (sex) setSex(sex as MyInfo['sex'])
+      }}
+      className={styles.ToggleGroup}
+      type="single"
+      aria-label="성별을 선택하세요"
+    >
+      <ToggleGroup.Item className={styles.ToggleGroupItem} value="남자">
+        남자
+      </ToggleGroup.Item>
+      <ToggleGroup.Item className={styles.ToggleGroupItem} value="여자">
+        여자
+      </ToggleGroup.Item>
+    </ToggleGroup.Root>
+  )
+}

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -7,6 +7,7 @@ import NotFoundPage from './NotFoundPage'
 import MyPage from './MyPage/MyPage'
 import { PartySurveyFormPage } from './PartySurveyForm/PartySurveyFormPage'
 import { PartyDetailPage } from './PartyDetailPage/PartyDetailPage'
+import MyInfoFormPage from './MyInfoFormPage/MyInfoFormPage'
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -16,6 +17,7 @@ const router = createBrowserRouter(
       <Route path="oauth" element={<OauthPage />} />
       <Route path="404" element={<NotFoundPage />} />
       <Route path="mypage" element={<MyPage />} />
+      <Route path="mypage/new" element={<MyInfoFormPage />} />
       <Route path="/party/:id" element={<PartyDetailPage />} />
       <Route path="party-suervey" element={<PartySurveyFormPage />} />
     </Route>

--- a/src/pages/types/api.ts
+++ b/src/pages/types/api.ts
@@ -2,25 +2,28 @@ export type MyProfile = {
   userId: number
   nickname: string
   profileImageUrl: string
+  description?: string
+  skillLevel?: string
+  sex?: string
 }
 
 export type Party = {
   createdAt: string
   updatedAt: string
   id: number
-  constraints: "BOTH" | "MALE_ONLY" | "FEMALE_ONLY"
+  constraints: 'BOTH' | 'MALE_ONLY' | 'FEMALE_ONLY'
   minSkillLevel: number
-  maxSkillLevel:	number
+  maxSkillLevel: number
   locationId: number
   participationDeadline: string
   description: string
-  userLimitCount:	number
-  currentTotalMemberCount:	number
-  approacheDescription:	string
+  userLimitCount: number
+  currentTotalMemberCount: number
+  approacheDescription: string
   appointmentTime: string
-  climbingType:	"BOULDERING" | "LEAD" | "ENDURANCE" | "ANY"
+  climbingType: 'BOULDERING' | 'LEAD' | 'ENDURANCE' | 'ANY'
   masterId: number
-  partyTitle:	string
+  partyTitle: string
   natural: boolean
 }
 

--- a/src/reset.css
+++ b/src/reset.css
@@ -36,6 +36,7 @@ h5,
 h6,
 p {
   overflow-wrap: break-word;
+  all: unset;
 }
 #__next,
 #root {
@@ -54,5 +55,9 @@ li {
   all: unset;
 }
 a {
+  all: unset;
+}
+
+fieldset {
   all: unset;
 }

--- a/src/services/party.ts
+++ b/src/services/party.ts
@@ -6,22 +6,24 @@ import { queryClient } from '@/utils/tanstack'
 import { ClimbingTypeEn, GenderEn } from '@/pages/PartySurveyForm/components/PartyConditionForm.tsx'
 import dayjs from 'dayjs'
 
-/************* GET Party List **************/
+/**
+ * GET /v1/party/list?${queryString}
+ */
 export type GetPartyListParams = {
   page?: number
   size?: number
-  sortColumn?: "CREATED_AT"
-  sortOrder?: "DESC" | "ASC"
+  sortColumn?: 'CREATED_AT'
+  sortOrder?: 'DESC' | 'ASC'
   isNatural?: boolean
-  climbingType?: "BOULDERING" | "LEAD" | "ENDURANCE" | "ANY"
-  constraints?: "BOTH" | "MALE_ONLY" | "FEMALE_ONLY"
+  climbingType?: 'BOULDERING' | 'LEAD' | 'ENDURANCE' | 'ANY'
+  constraints?: 'BOTH' | 'MALE_ONLY' | 'FEMALE_ONLY'
   appointmentDate?: string
   address1List?: string[]
   locationId?: number
 }
 
 export const get_party_list = async (params?: GetPartyListParams) => {
-  const queryString = params ? `?${stringify(params)}` : ""
+  const queryString = params ? `?${stringify(params)}` : ''
 
   try {
     const result = await api.get<PageData<Party>>(`/v1/party/list?${queryString}`)
@@ -37,9 +39,10 @@ export const PARTY_LIST_KEY = ['party', 'list']
 export const usePartyList = (params?: GetPartyListParams) => {
   return useSuspenseInfiniteQuery({
     queryKey: [PARTY_LIST_KEY, params && stringify(params)],
-    queryFn: ({pageParam}) => get_party_list({...params, page: pageParam ?? 0}),
+    queryFn: ({ pageParam }) => get_party_list({ ...params, page: pageParam ?? 0 }),
     initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.totalPages <= lastPage.pageable.pageNumber ? null : lastPage.pageable.pageNumber + 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.totalPages <= lastPage.pageable.pageNumber ? null : lastPage.pageable.pageNumber + 1,
     // 마운트시에 요청 보내지 않음
     retryOnMount: false,
     // 윈도우 포커스시에 새로고침하지 않음
@@ -115,8 +118,9 @@ export class PartyItem {
   }
 }
 
-
-/************* POST Party New **************/
+/**
+ * POST /v1/party/new
+ */
 export type PostPartyNewReq = {
   constraints: GenderEn
   climbingType: ClimbingTypeEn

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -4,6 +4,9 @@ import { MyProfile } from '../pages/types/api'
 import { isAxiosError } from 'axios'
 import { queryClient } from '../utils/tanstack'
 
+/**
+ * GET /v1/user/myProfile
+ */
 export const get_user_myProfile = async () => {
   return await api.get<MyProfile>('/v1/user/myProfile')
 }
@@ -48,4 +51,91 @@ export const MyProfileQuery = {
     await queryClient.refetchQueries({
       queryKey: USER_KEY,
     }),
+}
+
+/**
+ * POST /v1/user/additional-info
+ */
+export const post_user_additionalInfo = async (params: PostAdditonalInfoParams) => {
+  return await api.post<PostAdditonalInfoParams>('/v1/user/additional-info', params)
+}
+
+export type PostAdditonalInfoParams = {
+  description: string
+  sex: 'MALE' | 'FEMALE'
+  skill:
+    | 'BLUE'
+    | 'RED'
+    | 'WHITE'
+    | 'YELLOW'
+    | 'ORANGE'
+    | 'GREEN'
+    | 'PURPLE'
+    | 'GREY'
+    | 'BROWN'
+    | 'BLACK'
+}
+
+export type MyInfo = {
+  sex: '남자' | '여자'
+  skill:
+    | 'BLUE'
+    | 'RED'
+    | 'WHITE'
+    | 'YELLOW'
+    | 'ORANGE'
+    | 'GREEN'
+    | 'PURPLE'
+    | 'GREY'
+    | 'BROWN'
+    | 'BLACK'
+  description: string
+}
+
+export const skillOptions: MyInfo['skill'][] = [
+  'BLUE',
+  'RED',
+  'WHITE',
+  'YELLOW',
+  'ORANGE',
+  'GREEN',
+  'PURPLE',
+  'GREY',
+  'BROWN',
+  'BLACK',
+]
+
+export class AdditionalInfoAddapter {
+  private value: MyInfo
+
+  constructor(value: MyInfo) {
+    this.value = value
+  }
+
+  get description(): PostAdditonalInfoParams['description'] {
+    return this.value.description
+  }
+
+  get sex(): PostAdditonalInfoParams['sex'] {
+    switch (this.value.sex) {
+      case '남자':
+        return 'MALE'
+      case '여자':
+        return 'FEMALE'
+      default:
+        return 'MALE'
+    }
+  }
+
+  get skill(): PostAdditonalInfoParams['skill'] {
+    return this.value.skill
+  }
+
+  adapt() {
+    return {
+      description: this.description,
+      sex: this.sex,
+      skill: this.skill,
+    }
+  }
 }


### PR DESCRIPTION
## 유저 추가 정보 입력 페이지 

<img width="200" alt="스크린샷 2024-06-23 오후 9 17 02" src="https://github.com/Climeeting/climeet-fe/assets/76723666/8bf661a6-7a63-4f51-a0f7-94ccf40d3e95">
<img width="200" alt="스크린샷 2024-06-23 오후 9 17 18" src="https://github.com/Climeeting/climeet-fe/assets/76723666/e8a59cfa-49fc-4eb5-aa4b-d6b4bb02ca77">

## 작업 내용

- 유저 추가 정보 입력 페이지 생성
- radix ui 사용해 성별은 토글 그룹 컴포넌트로 구현
- api 연결

아직 구체적인 기획/디자인이 나오지 않아서 임시 작업입니다~
파티 생성시 유저 정보 추가가 필요하여 해당 페이지에서 본인 정보 추가하시고 파티생성 하시면 될거같습니당!
